### PR TITLE
fix: update Bindle download URL for macOS

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -70,7 +70,7 @@ export function installLocation(tool: string, bin: string): string {
 function os(): string | null {
     switch (process.platform) {
         case 'win32': return 'windows';
-        case 'darwin': return 'darwin';
+        case 'darwin': return 'macos';
         case 'linux': return 'linux';
         default: return null;
     }


### PR DESCRIPTION
This PR updates the Bindle download URL for the correct one on macOS.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>