### PR TITLE
Refine and document environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,59 @@
 # autobindle
 
 A VS Code extension that makes your life easier if you've got a Bindle server in your dev workflow.
+
+## Usage
+
+Some development workflows, such as when using Wasm components or building Hippo applications,
+use a Bindle server as their registry of application binaries and assets. This extension
+simplifies the process of standing up a local development Bindle server. It automatically
+downloads the Bindle server binary if requires, runs it on a port of your choice, and
+stops it when you close your workspace.
+
+## Basic Commands
+
+* `Bindle: Start` starts the Bindle server.  If it's the first time you've run this command, it
+  first downloads the Bindle server binary, which can take a little while.  After that it uses
+  the cached binary so is much faster to start up!
+* `Bindle: Stop` stops the currently running Bindle server.
+
+The Bindle server uses a file system based back end, with storage under your home directory.
+Access is unauthenticated so be sure that the Bindle port is not exposed to other machines!
+
+While Bindle is running, the word `Bindle` is displayed in the status bar. You can hover over
+this to see the Bindle port.
+
+## Environments
+
+The environments feature allows you to have multiple server configurations with different
+backing directories. This allows you to keep projects separate, or to maintain a stable
+integration testing environment while also having a scratch area for messing around.
+
+Each environment is backed by its own data directory. You can only have one environment active
+at a time. You don't need to set up environments unless you want to (the extension creates
+and uses a default one automatically).
+
+* `Bindle: Switch Environment` updates your configuration to point to a new data directory.
+  If Bindle is running, it is restarted with the newly chosen directory.
+* `Bindle: New Environment` creates a new environment backed by a directory under your
+  home directory. It automatically switches to the new environment, so this restarts
+  Bindle if it's running.
+* `Bindle: New Environment in Chosen Folder` creates a new environment but allows you to
+  choose the backing directory. This can be useful if, for example, your project contains
+  its own set of test bindles.
+
+You can hover over the `Bindle` status bar item to see which environment you're currently in.
+
+## Configuration
+
+The extension defines the following configuration entries:
+
+* `autobindle.port`: The port on which to serve. If not specified this defaults to 8080.
+* `autobindle.activeEnvironment`: The name of the currently selected environment. You won't
+  normally need to edit this manually - use the Switch Environemnt command instead.
+* `autobindle.environments`: The list of environments (names and backing directories).
+  You won't normally need to edit this manually - use the New Environment commands instead.
+
+The `environments` setting can be set at a machine level only - this prevents a workspace
+overriding the setting.  The `activeEnvironment` setting can be set at any level, so you can
+associate a project to its own Bindle environment. This is applied only in trusted workspaces.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "onCommand:autobindle.start",
         "onCommand:autobindle.stop",
         "onCommand:autobindle.switch",
-        "onCommand:autobindle.new"
+        "onCommand:autobindle.new",
+        "onCommand:autobindle.newInFolder"
     ],
     "main": "./dist/extension.js",
     "contributes": {
@@ -37,6 +38,11 @@
                 "command": "autobindle.new",
                 "category": "Bindle",
                 "title": "New Environment"
+            },
+            {
+                "command": "autobindle.newInFolder",
+                "category": "Bindle",
+                "title": "New Environment in Chosen Folder"
             }
         ],
         "configuration": {
@@ -67,6 +73,16 @@
                     "type": "string"
                 }
             }
+        }
+    },
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": "limited",
+            "description": "Untrusted projects may not specify their own environments",
+            "restrictedConfigurations": [
+                "autobindle.activeEnvironment",
+                "autobindle.environments"
+            ]
         }
     },
     "scripts": {

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -87,9 +87,14 @@ export async function setEnvironment(environmentName: string, storagePath: strin
 
 async function createDefaultEnvironment(): Promise<BindleEnvironment> {
     const name = "default";
+    const storagePath = autoStoragePath(name);
+    return await setEnvironment(name, storagePath);
+}
+
+export function autoStoragePath(name: string) {
     const basePath = layout.dataFolder();
     const storagePath = path.join(basePath, name);
-    return await setEnvironment(name, storagePath);
+    return storagePath;
 }
 
 function asQuickPick(environment: BindleEnvironment): vscode.QuickPickItem & { readonly environment: BindleEnvironment } {


### PR DESCRIPTION
I suspect a lot of the time people aren't going to care that much about where a data set lives, they just want the partitioning.  So this PR changes the New Environment command to automate the choice of storage path, and renames the old command to New Environment In Chosen Folder.

Environments are now documented and play safely with untrusted workspaces (restricted mode).